### PR TITLE
Currect typing error Reigon* -> Region*, sizeof(RegionKey)

### DIFF
--- a/Sources/Blocks/BiomeManager.cpp
+++ b/Sources/Blocks/BiomeManager.cpp
@@ -157,21 +157,21 @@ Biome BiomeManager::GetBiome(glm::vec3 position)
 {
     float      regionValue;
 
-    ReigonKey  regionKey;
-    ReigonData regionData;
+    RegionKey  regionKey;
+    RegionData regionData;
 
     regionData.x = static_cast<short>(static_cast<int>(position.x) / Chunk::CHUNK_SIZE);
     regionData.y = static_cast<short>(static_cast<int>(position.y) / Chunk::CHUNK_SIZE);
     regionData.z = static_cast<short>(static_cast<int>(position.z) / Chunk::CHUNK_SIZE);
 
-    memcpy(&regionKey, &regionData, sizeof(unsigned long));
+    memcpy(&regionKey, &regionData, sizeof(RegionKey));
 
     auto iterator = m_biomeCached.find(regionKey);
 
     if (iterator == m_biomeCached.end())
     {
         regionValue = static_cast<float>(m_biomeRegions.GetValue(position.x, position.y, position.z));
-        m_biomeCached.insert(std::pair<ReigonKey, float>(regionKey, regionValue));
+        m_biomeCached.insert(std::pair<RegionKey, float>(regionKey, regionValue));
     } else regionValue = iterator->second;
 
 	float ratio = 1.0f / (static_cast<int>(Biome::NumBiomes) - 1.0f);

--- a/Sources/Blocks/BiomeManager.h
+++ b/Sources/Blocks/BiomeManager.h
@@ -40,11 +40,11 @@ struct BiomeHeightBoundary
 	BlockType m_blockType;
 };
 
-typedef unsigned long long ReigonKey;
+typedef unsigned long long RegionKey;
 
 #pragma pack(push)
 #pragma pack(2)
-struct ReigonData
+struct RegionData
 {
     short x;
     short y;
@@ -116,7 +116,7 @@ private:
 	Renderer* m_pRenderer;
 
     // Cached Biome data.
-    std::unordered_map<ReigonKey, float> m_biomeCached;
+    std::unordered_map<RegionKey, float> m_biomeCached;
 
 	// Biome voronoi regions
 	noise::module::Voronoi m_biomeRegions;


### PR DESCRIPTION
Currect typing error `ReigonKey`, `ReigonData` -> `RegionKey`, `RegionData`.

Fix RegionKey memcpy Bug `BiomeManager` line 169, `sizeof(unsigned long)` -> `sizeof(RegionKey)`
